### PR TITLE
Deprecate `/v1/block-height` endpoint

### DIFF
--- a/Partners/qubic-http.swagger.json
+++ b/Partners/qubic-http.swagger.json
@@ -138,6 +138,7 @@
     },
     "/v1/block-height": {
       "get": {
+        "summary": "/v1/block-height Deprecated in favor of /v1/tick-info",
         "operationId": "QubicLiveService_GetBlockHeight",
         "responses": {
           "200": {


### PR DESCRIPTION
Add description for /v1/block-height that is now deprecated in favor of tick-info.