### PR TITLE
fix: generate Query API OpenAPI spec from dispatched commit SHA

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -31,9 +31,39 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v6
 
-      - name: Decode Query API OpenAPI spec from payload
+      - name: Checkout archive-query-service
+        uses: actions/checkout@v6
+        with:
+          repository: qubic/archive-query-service
+          ref: ${{ github.event.client_payload.ref || 'main' }}
+          path: archive-query-service
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26.x
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Install protoc-gen-openapi
+        run: go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
+
+      - name: Generate OpenAPI spec
+        working-directory: archive-query-service/v2
         run: |
-          echo "${{ github.event.client_payload.openapi_spec_base64 }}" | base64 -d > Partners/swagger/query_services.openapi.yaml
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          make openapi-v3-gen
+
+      - name: Apply OpenAPI adjustments
+        run: |
+          cd archive-query-service/v2/api/archive-query-service/v2
+          yq -i --indent 4 'del(.paths."/health")' query_services.openapi.yaml
+          yq -i --indent 4 '(.tags[] | select(.name == "ArchiveQueryService")).x-scalar-ignore = true' query_services.openapi.yaml
+          yq -i --indent 4 '(.paths[][].tags) -= ["ArchiveQueryService"]' query_services.openapi.yaml
+
+      - name: Copy spec into place
+        run: cp archive-query-service/v2/api/archive-query-service/v2/query_services.openapi.yaml Partners/swagger/query_services.openapi.yaml
 
       - name: Commit and Push
         run: |


### PR DESCRIPTION
Receive the commit SHA in client_payload instead of an inlined base64 spec, then check out qubic/archive-query-service at that SHA and generate the spec locally. Avoids GitHub's 65535-character client_payload limit.